### PR TITLE
Specify PRE font styles

### DIFF
--- a/share/static/style.css
+++ b/share/static/style.css
@@ -2,3 +2,8 @@ body {
     background: black;
     color: #bbbbbb;
 }
+
+pre {
+    font-family: Menlo, 'Lucida Sans Typewriter', 'Lucida Console', Monaco, 'Bitstream Vera Sans Mono', monospace;
+    font-size: 75%;
+}


### PR DESCRIPTION
Adapted from what the website is serving but added Menlo, which works
much better on OS X, fixing issue #22 on that platform.